### PR TITLE
Support hazelcast 3.11

### DIFF
--- a/src/main/java/com/hazelcast/azure/AzureDiscoveryStrategyFactory.java
+++ b/src/main/java/com/hazelcast/azure/AzureDiscoveryStrategyFactory.java
@@ -34,14 +34,21 @@ import java.util.Map;
  */
 public class AzureDiscoveryStrategyFactory implements DiscoveryStrategyFactory {
 
+    private static final Collection<PropertyDefinition> ALL_PROPERTY_DEFINITIONS;
     private static final Collection<PropertyDefinition> REQUIRED_PROPERTY_DEFINITIONS;
 
     static {
-        List<PropertyDefinition> propertyDefinitions = new ArrayList<PropertyDefinition>();
-        propertyDefinitions.add(AzureProperties.SUBSCRIPTION_ID);
-        propertyDefinitions.add(AzureProperties.GROUP_NAME);
-        propertyDefinitions.add(AzureProperties.CLUSTER_ID);
-        REQUIRED_PROPERTY_DEFINITIONS = Collections.unmodifiableCollection(propertyDefinitions);
+        List<PropertyDefinition> requiredPropertyDefinitions = new ArrayList<PropertyDefinition>();
+        requiredPropertyDefinitions.add(AzureProperties.CLUSTER_ID);
+        requiredPropertyDefinitions.add(AzureProperties.GROUP_NAME);
+        requiredPropertyDefinitions.add(AzureProperties.SUBSCRIPTION_ID);
+        REQUIRED_PROPERTY_DEFINITIONS = Collections.unmodifiableCollection(requiredPropertyDefinitions);
+
+        List<PropertyDefinition> allPropertyDefinitions = new ArrayList<PropertyDefinition>(requiredPropertyDefinitions);
+        allPropertyDefinitions.add(AzureProperties.CLIENT_ID);
+        allPropertyDefinitions.add(AzureProperties.CLIENT_SECRET);
+        allPropertyDefinitions.add(AzureProperties.TENANT_ID);
+        ALL_PROPERTY_DEFINITIONS = Collections.unmodifiableCollection(allPropertyDefinitions);
     }
 
     @Override
@@ -67,6 +74,6 @@ public class AzureDiscoveryStrategyFactory implements DiscoveryStrategyFactory {
      * @return {@code Collection<PropertyDefinition>} the property defitions for the AzureDiscoveryStrategy
      */
     public Collection<PropertyDefinition> getConfigurationProperties() {
-        return REQUIRED_PROPERTY_DEFINITIONS;
+        return ALL_PROPERTY_DEFINITIONS;
     }
 }

--- a/src/test/java/com/hazelcast/azure/AzureDiscoveryStrategyFactoryTest.java
+++ b/src/test/java/com/hazelcast/azure/AzureDiscoveryStrategyFactoryTest.java
@@ -53,9 +53,12 @@ public class AzureDiscoveryStrategyFactoryTest extends HazelcastTestSupport {
         AzureDiscoveryStrategyFactory factory = new AzureDiscoveryStrategyFactory();
         Collection<PropertyDefinition> properties = factory.getConfigurationProperties();
 
-        assertTrue(properties.contains(AzureProperties.SUBSCRIPTION_ID));
+        assertTrue(properties.contains(AzureProperties.CLIENT_ID));
+        assertTrue(properties.contains(AzureProperties.CLIENT_SECRET));
         assertTrue(properties.contains(AzureProperties.CLUSTER_ID));
         assertTrue(properties.contains(AzureProperties.GROUP_NAME));
+        assertTrue(properties.contains(AzureProperties.SUBSCRIPTION_ID));
+        assertTrue(properties.contains(AzureProperties.TENANT_ID));
     }
 
     @Test


### PR DESCRIPTION
Hazelcast 3.11 has become stricter with the configuration parameters for discovery plugin. All the parameters used by a plugin should be defined, even if the configuration parameter is optional.