### PR TITLE
Upgrade okhttp to 4.10.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <atomikos.version>3.9.3</atomikos.version>
         <log4j.version>1.2.12</log4j.version>
         <bytebuddy.version>1.6.12</bytebuddy.version>
-        <okhttp.version>4.9.2</okhttp.version>
+        <okhttp.version>4.10.0</okhttp.version>
     </properties>
 
     <build>


### PR DESCRIPTION
Bump `okhttp` from 4.9.2 introduced by azure-client-authentication to 4.10.0 to include the vuln patch.
(Latest version of azure-client-authentication still using a vulnerable version 3.12.12 of okhttp).

Vuln recorded at: https://security.snyk.io/vuln/SNYK-JAVA-COMSQUAREUPOKIO-5773320