### PR TITLE
Upgrade okhttp to 4.12.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -111,7 +111,7 @@
         <atomikos.version>3.9.3</atomikos.version>
         <log4j.version>1.2.12</log4j.version>
         <bytebuddy.version>1.6.12</bytebuddy.version>
-        <okhttp.version>4.9.2</okhttp.version>
+        <okhttp.version>4.10.0</okhttp.version>
     </properties>
 
     <build>

--- a/pom.xml
+++ b/pom.xml
@@ -27,7 +27,7 @@
     <description>An Azure DiscoveryStrategy for Hazelcast</description>
     <groupId>com.hazelcast</groupId>
     <artifactId>hazelcast-azure</artifactId>
-    <version>2.0.0-atlassian-6-SNAPSHOT</version>
+    <version>2.0.0-atlassian-8-SNAPSHOT</version>
     <url>http://www.hazelcast.com/</url>
     <packaging>jar</packaging>
 
@@ -111,7 +111,7 @@
         <atomikos.version>3.9.3</atomikos.version>
         <log4j.version>1.2.12</log4j.version>
         <bytebuddy.version>1.6.12</bytebuddy.version>
-        <okhttp.version>4.10.0</okhttp.version>
+        <okhttp.version>4.12.0</okhttp.version>
     </properties>
 
     <build>


### PR DESCRIPTION
Bump `okhttp` to version 4.12.0 (latest), which uses the `okio` 3.6.0 that is not vulnerable to https://nvd.nist.gov/vuln/detail/CVE-2023-3635.