### PR TITLE
BSERV-18908 add in nimbus dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -103,6 +103,7 @@
         <maven.rar.plugin.version>2.2</maven.rar.plugin.version>
         <maven.gpg.plugin.version>1.4</maven.gpg.plugin.version>
         <maven.javadoc.plugin.version>2.9</maven.javadoc.plugin.version>
+        <nimbus.version>6.5</nimbus.version>
 
         <junit.version>4.12</junit.version>
         <mockito.version>1.10.19</mockito.version>
@@ -265,6 +266,11 @@
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure-mgmt-compute</artifactId>
             <version>${azure.mgmt.sdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>oauth2-oidc-sdk</artifactId>
+            <version>${nimbus.version}</version>
         </dependency>
         <!-- This dependency is here to patch a vulnerability in the version of okhttp used by
         azure-client-authentication. More information can be found here: https://github.com/square/okhttp/issues/6738


### PR DESCRIPTION
Add in dependency for `com.nimbusds:oauth2-oidc-sdk` used by `azure-client-authentication` to ensure node discovery works for stash in azure.

Side note: Tried to upgrade `azure-client-authentication` to 1.7.14 and `nimbusds` to 9.4, however, got `InaccessibleObjectException` and could not resolve easily (and out of scope for the task).

`2023-10-31 04:30:09,905 TRACE [spring-startup]  c.h.i.m.m.OperatingSystemMetricSet Unable to register OperatingSystemMXBean method getCommittedVirtualMemorySize used for probe os.committedVirtualMemorySize
java.lang.reflect.InaccessibleObjectException: Unable to make public long com.sun.management.internal.OperatingSystemImpl.getCommittedVirtualMemorySize() accessible: module jdk.management does not "opens com.sun.management.internal" to unnamed module @151db587
        at java.base/java.lang.reflect.AccessibleObject.checkCanSetAccessible(AccessibleObject.java:340)
        at com.hazelcast.internal.metrics.metricsets.OperatingSystemMetricSet.getMethod(OperatingSystemMetricSet.java:131)
        at com.hazelcast.internal.metrics.metricsets.OperatingSystemMetricSet.registerMethod(OperatingSystemMetricSet.java:97)
        at com.hazelcast.internal.metrics.metricsets.OperatingSystemMetricSet.registerMethod(OperatingSystemMetricSet.java:91)
        at com.hazelcast.internal.metrics.metricsets.OperatingSystemMetricSet.register(OperatingSystemMetricSet.java:56)
        at com.hazelcast.spi.impl.NodeEngineImpl.start(NodeEngineImpl.java:199)
        at com.hazelcast.instance.Node.start(Node.java:430)
        at com.hazelcast.instance.HazelcastInstanceImpl.<init>(HazelcastInstanceImpl.java:136)
        at com.hazelcast.instance.HazelcastInstanceFactory.constructHazelcastInstance(HazelcastInstanceFactory.java:203)
        at com.hazelcast.instance.HazelcastInstanceFactory.newHazelcastInstance(HazelcastInstanceFactory.java:182)
        at com.hazelcast.instance.HazelcastInstanceFactory.newHazelcastInstance(HazelcastInstanceFactory.java:132)
        at com.hazelcast.core.Hazelcast.newHazelcastInstance(Hazelcast.java:57)
        at com.atlassian.stash.internal.hazelcast.HazelcastFactoryBean.newInstance(HazelcastFactoryBean.java:126)
        at com.atlassian.stash.internal.hazelcast.HazelcastFactoryBean.createInstance(HazelcastFactoryBean.java:66)
        at com.atlassian.stash.internal.hazelcast.HazelcastFactoryBean.createInstance(HazelcastFactoryBean.java:34)
        at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:920)
        at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:583)
        at javax.servlet.GenericServlet.init(GenericServlet.java:158)
        at java.base/java.lang.Thread.run(Thread.java:829)
        ... 37 frames trimmed`
        
Ideally should probably bump the `azure-client-authentication` version, as 1.7.2 has a vulnerability since 2020. https://mvnrepository.com/artifact/com.microsoft.azure/azure-client-authentication/1.7.2
