### PR TITLE
Bump nimbus to 9.4 and azure client auth to 1.7.14

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -90,7 +90,7 @@
 
         <hazelcast.version>3.7.2</hazelcast.version>
 
-        <azure.client.authentication.version>1.7.2</azure.client.authentication.version>
+        <azure.client.authentication.version>1.7.14</azure.client.authentication.version>
         <azure.mgmt.sdk.version>1.14.0</azure.mgmt.sdk.version>
 
         <maven.findbugs.plugin.version>3.0.0</maven.findbugs.plugin.version>
@@ -103,7 +103,7 @@
         <maven.rar.plugin.version>2.2</maven.rar.plugin.version>
         <maven.gpg.plugin.version>1.4</maven.gpg.plugin.version>
         <maven.javadoc.plugin.version>2.9</maven.javadoc.plugin.version>
-        <nimbus.version>6.5</nimbus.version>
+        <nimbus.version>9.4</nimbus.version>
 
         <junit.version>4.12</junit.version>
         <mockito.version>1.10.19</mockito.version>


### PR DESCRIPTION
Addresses https://security.snyk.io/vuln/SNYK-JAVA-COMNIMBUSDS-1243767 (CWE-611), as nimbus:oauth2-oidc-sdk 9.4 is not vulnerable to XML External Entity (XXE) Injection via the SAML2AssertionValidator method (but 6.5 is).

azure-client-authentication 1.7.14 is required as it uses adal4j 1.6.7 which uses nimbus 9.4. Older azure-client-auth versions use adal4j 1.6.4, which uses nimbus 6.5, and adal4j 1.6.4 directly uses `CommonContentTypes` which was removed in nimbus 7.0.
- Nimbus diff/changelog: https://bitbucket.org/connect2id/oauth-2.0-sdk-with-openid-connect-extensions/branches/compare/9.4%0D6.5#LCHANGELOG.txtT1049
- Azure-client-auth diff: https://github.com/Azure/autorest-clientruntime-for-java/compare/v1.7.2...v1.7.14#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L17

******

Node discovery still worked when getting the same `InaccessibleObjectException` errors mentioned in https://github.com/atlassian/hazelcast-azure/pull/14 (`c.h.i.m.m.OperatingSystemMetricSet Unable to register OperatingSystemMXBean method getCommittedVirtualMemorySize...`):
```log
2023-12-15 04:31:45,048 INFO  [main]  c.a.b.i.b.BitbucketServerApplication Starting BitbucketServerApplication v8.9.9-SNAPSHOT using Java 11.0.21 on bbdc-hz-nd-vm1 with PID 81304 (/opt/n9/app/WEB-INF/classes started by hzazure10 in /opt/n9/bin)
2023-12-15 04:31:45,049 INFO  [main]  c.a.b.i.b.BitbucketServerApplication No active profile set, falling back to 1 default profile: "default"
2023-12-15 04:31:46,059 INFO  [main]  c.a.b.i.boot.log.BuildInfoLogger Starting Bitbucket 8.9.9-SNAPSHOT (0b3a856 built on Fri Dec 15 02:16:42 UTC 2023)
2023-12-15 04:31:46,059 INFO  [main]  c.a.b.i.boot.log.BuildInfoLogger JVM: Ubuntu OpenJDK 64-Bit Server VM 11.0.21+9-post-Ubuntu-0ubuntu120.04
2023-12-15 04:31:47,495 INFO  [main]  c.a.b.i.b.BitbucketServerApplication Started BitbucketServerApplication in 3.719 seconds (JVM running for 4.691)
2023-12-15 04:31:50,523 INFO  [spring-startup]  c.a.s.internal.home.HomeLockAcquirer Successfully acquired lock on home directory /var/n94
2023-12-15 04:31:55,063 INFO  [spring-startup]  c.a.s.internal.home.HomeLockAcquirer Successfully acquired lock on home directory /var/n94/shared
...
2023-12-15 04:31:56,543 TRACE [spring-startup]  c.h.i.m.m.OperatingSystemMetricSet Unable to register OperatingSystemMXBean method getCommittedVirtualMemorySize used for probe os.committedVirtualMemorySize
java.lang.reflect.InaccessibleObjectException: Unable to make public long com.sun.management.internal.OperatingSystemImpl.getCommittedVirtualMemorySize() accessible: module jdk.management does not "opens com.sun.management.internal" to unnamed module @7a2b1eb4
...
2023-12-15 04:45:42,509 INFO  [hz.hazelcast.generic-operation.thread-1]  c.h.internal.cluster.ClusterService [10.0.0.4]:5701 [hzazure10] [3.12.13] 

Members {size:2, ver:3} [
	Member [10.0.0.4]:5701 - 55c192ba-773e-44c9-997b-ea40c3c51d03 this
	Member [10.0.0.5]:5701 - 0f593cb0-d201-4674-bc6b-125262e3603b lite
]

2023-12-15 04:45:42,518 INFO  [hz.hazelcast.event-2]  c.a.s.i.c.HazelcastClusterService Node '/10.0.0.5:5701' was ADDED to the cluster. Updated cluster: 
	[/10.0.0.4:5701 master this uuid='55c192ba-773e-44c9-997b-ea40c3c51d03' vm-id='85f27649-ad60-4dbe-a26b-2cf1ca1bd4e5'], 
	[/10.0.0.5:5701 uuid='0f593cb0-d201-4674-bc6b-125262e3603b' vm-id='167374e0-9733-47e9-879d-6dcf4c8197e1']
```

Adding `--add-opens=jdk.management/com.sun.management.internal=ALL-UNNAMED"` to `_start-webapp.sh`'s `JVM_JAVA_ARGS` as mentioned in https://stackoverflow.com/a/56339895 resolved the above errors (will raise PR for Stash to address this).

Node discovery was manually tested in Azure with 2 nodes.

