### PR TITLE
Add explicit dependency on nimbus-jose-jwt 9.37.3 (CVE-2023-52428)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -104,6 +104,7 @@
         <maven.gpg.plugin.version>1.4</maven.gpg.plugin.version>
         <maven.javadoc.plugin.version>2.9</maven.javadoc.plugin.version>
         <nimbus.version>9.4</nimbus.version>
+        <nimbus.jose.jwt.version>9.37.3</nimbus.jose.jwt.version>
 
         <junit.version>4.12</junit.version>
         <mockito.version>1.10.19</mockito.version>
@@ -266,6 +267,11 @@
             <groupId>com.microsoft.azure</groupId>
             <artifactId>azure-mgmt-compute</artifactId>
             <version>${azure.mgmt.sdk.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.nimbusds</groupId>
+            <artifactId>nimbus-jose-jwt</artifactId>
+            <version>${nimbus.jose.jwt.version}</version>
         </dependency>
         <dependency>
             <groupId>com.nimbusds</groupId>


### PR DESCRIPTION
Pinning the version of com.nimbusds:nimbus-jose-jwt to 9.37.3 to address https://www.cve.org/CVERecord?id=CVE-2023-52428 as com.nimbusds:oauth2-oidc-sdk 9.4 brings in a vulnerable version of nimbus-jose-jwt (9.8.1).

Nimbus changelog: https://bitbucket.org/connect2id/nimbus-jose-jwt/branches/compare/9.37.3%0D9.8.1#chg-CHANGELOG.txt

Node discovery currently being manually tested in Azure with 2 nodes. Will update once successfully completed.